### PR TITLE
Update join_team.html to properly display labels

### DIFF
--- a/templates/teams/join_team.html
+++ b/templates/teams/join_team.html
@@ -17,11 +17,11 @@
 				{% with form = Forms.teams.TeamJoinForm() %}
 				<form method="POST">
 					<div class="form-group">
-						{{ form.name.label }}
+						<b>{{ form.name.label }}</b>
 						{{ form.name(class="form-control") }}
 					</div>
 					<div class="form-group">
-						{{ form.password.label }}
+						<b>{{ form.password.label }}</b>
 						{{ form.password(class="form-control") }}
 					</div>
 					<div class="row pt-3">


### PR DESCRIPTION
The join_team page doesn't have \<b> tags surrounding the "Team Name" and "Team Password" labels, causing them to not be visible to the client. These tags are present on the new_team.html file. Adding the tags fixes the issue.